### PR TITLE
Fixed syntax highlighting of the Swift code blocks

### DIFF
--- a/Delegates.md
+++ b/Delegates.md
@@ -14,8 +14,7 @@ Delegates augment existing behavior in the delegating object, they don't provide
 Provide an extension with default implementations after the protocol definition. This is preferred because the conforming types don't have to be Objective-C compatible.
 
 #### Example
-``` Swift
-
+``` swift
 protocol DiceGameDelegate {
 
     func gameShouldStart(_ game: DiceGame)
@@ -42,7 +41,7 @@ extension DiceGameDelegate {
 Define all the methods as optional. This can only be done if the protocol is available from Objective-C (has the `@objc` attribute). All conforming types will need to be Objective-C compatible.
 
 #### Example
-``` Swift
+``` swift
 @objc protocol DiceGameDelegate {
 
     @objc optional func gameShouldStart(_ game: DiceGame)

--- a/EarlyReturn.md
+++ b/EarlyReturn.md
@@ -5,7 +5,7 @@
 It's recommended to use `guard ... else` statements and early exits on top of a function to validate parameters or other variables.
 
 ## Syntax
-``` Swift
+``` swift
 func someFunction(argumentLabel parameterName: parameterType) {
     guard condition else {
         // log error or other actions
@@ -23,7 +23,7 @@ Using a guard statement to return early prevents parentheses nesting and better 
 
 ### Good: with early return, return value is a constant
 
-```Swift
+```swift
 class ElementList {
 
     func index(of element: Element) -> Int? {
@@ -49,7 +49,7 @@ class ElementList {
 
 ### Bad: without early return, return value is a variable
 
-```Swift
+```swift
 class ElementList {
 
     func index(of element: Element) -> Int? {

--- a/FileContentOrdering.md
+++ b/FileContentOrdering.md
@@ -10,7 +10,7 @@ Ordering file contents by access level ensures that the entities with the least 
 
 ## Example
 
-```Swift
+```swift
 // public enums, classes, interfaces etc.
 public class House {
 

--- a/Immutability.md
+++ b/Immutability.md
@@ -14,7 +14,7 @@ The Swift compiler enforces that the constants will not be changed unexpectedly 
 
 #### Good: the constant preserves immutability
 
-```Swift
+```swift
 func spacing(for orientation: NSUserInterfaceLayoutOrientation) -> Int {
     let spacing = orientation = .horizontal ? 25 : 15
     return spacing
@@ -23,7 +23,7 @@ func spacing(for orientation: NSUserInterfaceLayoutOrientation) -> Int {
 
 #### Bad: unnecessary use of variable does not preserve immutability
 
-```Swift
+```swift
 func spacing(for orientation: NSUserInterfaceLayoutOrientation) -> Int {
     var spacing: Int
     if orientation = .horizontal {
@@ -39,7 +39,7 @@ func spacing(for orientation: NSUserInterfaceLayoutOrientation) -> Int {
 
 #### Good: use a closure to calculate the value of the constant
 
-```Swift
+```swift
 enum Direction {
 	case north, south, east, west
 }
@@ -66,7 +66,7 @@ func move(point: (Int, Int), towards direction: Direction) {
 
 #### Bad: unnecessary use of variable does not preserve immutability
 
-```Swift
+```swift
 enum Direction {
 	case north, south, east, west
 }

--- a/Naming.md
+++ b/Naming.md
@@ -13,8 +13,7 @@ There's no three-letter prefix in Swift file naming. For example, if an Objectiv
 Provide a pre-fixed Objective-C name before the class or protocol definition. 
 
 #### Example
-``` Swift
-
+``` swift
 @objc class Event {
     // bad: exported to Objective-C as class Event without a prefix
 }
@@ -34,8 +33,7 @@ There is no need to add a prefix to a Swift protocol in order to distinguish it 
 - Protocols that describe a capability should be named using the suffixes able, ible, or ing (e.g. Equatable, ProgressReporting)."
 
 #### Example
-``` Swift
-
+``` swift
 protocol IFooEventHandler {
     // bad: the "I" prefix is not necessary
 }

--- a/PropertyObservers.md
+++ b/PropertyObservers.md
@@ -14,7 +14,7 @@ Checking whether the property value has actually changed can help avoid potentia
 
 ### Good: with `guard` statement, avoid doing unnecessary work
 
-``` Swift
+``` swift
 var propWithAnObserver: Bool {
     didSet {
         guard oldValue != propWithAnObserver else {
@@ -28,7 +28,7 @@ var propWithAnObserver: Bool {
 
 ### Bad: without `guard` statement, do unnecessary work
 
-``` Swift
+``` swift
 var propWithAnObserver: Bool {
     didSet {
         expensiveWork(propWithAnObserver)
@@ -45,7 +45,7 @@ Since the property assignment happens after the initializer with the use of `def
 
 ### Good: Avoid unnecessary duplicate calls to announceSymbol()
 
-``` Swift
+``` swift
 class House {
     init(symbol: String?) {
         defer {
@@ -66,7 +66,7 @@ class House {
 
 ### Bad: Unnecessary duplicate calls to announceSymbol()
 
-``` Swift
+``` swift
 class House {
     init(symbol: String?) {
         self.symbol = symbol

--- a/TypeInference.md
+++ b/TypeInference.md
@@ -16,7 +16,7 @@ When assigning an enum or a static property to a variable or a constant, if the 
 
 #### Good: use shorthand dot syntax
 
-``` Swift
+``` swift
 func layout(with direction: NSUserInterfaceLayoutOrientation) {
     switch direction {
     case .horizontal:
@@ -30,7 +30,7 @@ func layout(with direction: NSUserInterfaceLayoutOrientation) {
 
 #### Bad: unnecessarily verbose without shorthand dot syntax
 
-``` Swift
+``` swift
 func layout(with direction: NSUserInterfaceLayoutOrientation) {
     switch direction {
     case NSUserInterfaceLayoutOrientation.horizontal:
@@ -50,7 +50,7 @@ Let the compiler infer the type of a constant or variable whenever possible.
 
 #### Good: no left-hand-side type annotations
 
-``` Swift
+``` swift
 let horizontalMargin = 10
 
 let font = NSFont.systemFont(ofSize: 15.0)
@@ -58,7 +58,7 @@ let font = NSFont.systemFont(ofSize: 15.0)
 
 #### Bad: with unnecessary left-hand-side type annotations
 
-``` Swift
+``` swift
 let horizontalMargin: Int = 10
 
 let font: NSFont = NSFont.systemFont(ofSize: 15.0)
@@ -72,7 +72,7 @@ Use type annotations instead of type inference for properties for API clarity.
 
 #### Good: property use type annotations 
 
-``` Swift
+``` swift
 class CustomLabel {
     let textColor: UIColor = .white
 }
@@ -80,7 +80,7 @@ class CustomLabel {
 
 #### Bad: property does not use type annotations 
 
-``` Swift
+``` swift
 class CustomLabel {
     let textColor = UIColor.white
 }


### PR DESCRIPTION
Switching from "Swift" to "swift" so that GitHub Pages shows syntax highlighting for code blocks. Verified locally that syntax highlighting does show up.