### PR TITLE
added basic level of formatting information

### DIFF
--- a/Formatting.md
+++ b/Formatting.md
@@ -1,0 +1,46 @@
+# Formatting
+
+## Conventions
+
+Parameterized attributes are written on their own lines.
+
+
+## Rationale
+
+Parameterized attributes (such as @availability(...) or @objc(...)) are each written on their own line immediately before the declaration to which they apply.
+They are lexicographically ordered and are indented at the same level as the declaration.
+
+Attributes without parameters (for example, @objc without arguments, @IBOutlet, or @NSManaged) are lexicographically ordered and may be placed on the same line as the declaration.
+
+#### Example
+
+### Define a objc Protocol, enum, class, function:
+
+``` swift
+// good: @objc(XXX) defined in its own line 
+@objc(MSFActivityIndicatorViewSize)
+public enum ActivityIndicatorViewSize: Int, CaseIterable {
+	case xSmall
+	case small
+	case medium
+	case large
+	case xLarge
+}
+
+// good: as @objc does not contain any parameter, no need to separate it out to a different line.
+@objc func calculateSum(firstOperand: Int, secondOperand: Int) -> Int {
+	return firstOperand + secondOperand
+}
+
+// good: parameterized @objc(XXX)
+@objc(OFMActionsHandling)
+public protocol ActionsHandling: NSObjectProtocol {
+	@objc(handleActionFromViewController:inWindow:)
+	func handleAction(viewController: UIViewController, window: UIWindow)
+}
+
+
+@objc(MSFBlurringView) open class BlurringView: UIView {
+	// bad: @objc(XXX) class definition should be in a seperate line.
+}
+```

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The Swift coding conventions guide documents many best practices for writing Swi
 * [Naming](Naming.md)
 * [Property Observers](PropertyObservers.md)
 * [Type Inference](TypeInference.md)
+* [Formatting](Formatting.md)
 
 # Legal Notices
 


### PR DESCRIPTION
-- Parameterized attributes should be written in its own line.
-- If the attribute does not have any parameter, it can be written on the same line.
-- share some examples.