### PR TITLE
Update FileContentOrdering.md

### DIFF
--- a/FileContentOrdering.md
+++ b/FileContentOrdering.md
@@ -40,7 +40,7 @@ public class House {
 
 }
 
-// fileprivate extensions or constants
-fileprivate maximumHouseSize: Int = 50
+// private extensions or constants
+private maximumHouseSize: Int = 50
 ```
 


### PR DESCRIPTION
We recently updated our SwiftLint parsing on FluentUI Apple to prefer `private` over `fileprivate`. Let's reflect this in our public documentation