### PR TITLE
Add fileprivate example for content ordering

### DIFF
--- a/FileContentOrdering.md
+++ b/FileContentOrdering.md
@@ -16,7 +16,7 @@ public class House {
 
     // public functions
     public init {
-    ...
+    // ...
     }
 
     // public variables
@@ -24,15 +24,23 @@ public class House {
 
     // internal functions
     internal func addHouseMember() {
-    ...
+    // ...
     }
 
     // internal variables
     internal let sigil: Animal
 
+    // fileprivate functions
+    fileprivate func updateHouseAllegiance() {
+    // ...
+    }
+
+    // fileprivate variables
+    private var hasAllies: Bool
+
     // private functions
     private func reorganizeHouse() {
-    ...
+    // ...
     }
 
     // private variables

--- a/FileContentOrdering.md
+++ b/FileContentOrdering.md
@@ -36,7 +36,7 @@ public class House {
     }
 
     // fileprivate variables
-    private var hasAllies: Bool
+    fileprivate var hasAllies: Bool
 
     // private functions
     private func reorganizeHouse() {
@@ -46,6 +46,16 @@ public class House {
     // private variables
     private var size: Int = 0
 
+}
+
+// internal functions
+internal func updateUnalliedHouses(_ houses: [House]) {
+    houses.forEach { house in
+        // since this top-level function is in the same file, it can access fileprivate funcs and vars
+        if !house.hasAllies {
+            house.updateHouseAllegiance()
+        }
+    }
 }
 
 // private extensions or constants


### PR DESCRIPTION
Close #10 by adding a fileprivate example to the file ordering guidelines.