### PR TITLE
Merging naming convention with Outlook swift guide's naming convention

### DIFF
--- a/Naming.md
+++ b/Naming.md
@@ -9,11 +9,11 @@ In general, follow the [official guidelines](https://swift.org/documentation/api
 - All Swift files should use the `.swift` extension.
 - The name of a file should make it clear what the contents are. For example, if there is a single class named `EasyTapButton` then the file should be called `EasyTapButton.swift`. If you have a view controller, along with some helper types, then using the name of the view controller will likely be the best choice. A good heuristic to use is that if it's ever unclear what to name a file, it may be worth splitting that file up.
 - There's no three-letter prefix in Swift file naming. For example, if an Objective-C file named XYZEvent.m is to be converted to Swift, it should be renamed to Event.swift.
-- If a file contains only one or more extensions, then the file name should be `MyType+Extensions.swift` unless the extension have a specific name; in that case the extension should be named `MyType+ExtensionName.swift`.
+- If a file contains extensions, then the file name should be `MyType+Extensions.swift` unless the extension is purely adopting a protocol; in that case the extension should be named `MyType+ProtocolBeingConformedTo.swift`, for example `MyDictionary+NSCopying`.swift
 
 ### Naming a class, a struct or a protocol
 
-- Naming should be `PascalCase`
+- Naming should be `UpperCamelCase`
 - No Objective-C style prefixes should be used
 
 ### Naming a class or a protocol available in Objective-C
@@ -56,15 +56,19 @@ protocol FooEventHandling {
 
 ### Naming a delegate method
 
-The first parameter should always be the item that the delegate was called for.
+The first parameter should always be the item that is calling the delegate method.
+
+#### Rationale
+
+Dedicating the first parameter to be the item that is calling the delegate method follows Apple's API [design pattern](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/CodingGuidelines/Articles/NamingMethods.html#//apple_ref/doc/uid/20001282-1001803-BCIDAIJE).
 
 #### Example:
 
 ```swift
-// really bad: there's no parameter for the item that the delegate was called for
-func didDeleteDraft(draft: Draft)
+// really bad: there's no parameter for the item that is calling the delegate method.
+func didDeleteDraft()
 
-// bad: the item that the delegate was called for is not the first parameter
+// bad: the delegate method caller is not the first parameter
 func didDeleteDraft(draft: Draft, draftManager: DraftManager)
 
 // good
@@ -82,25 +86,25 @@ where `EventSource` is the UIControl or NSNotification which fired the event and
 #### Example:
 
 ```swift
-// Bad
-
+// bad: unclear what was the event source
 // An NSNotification handler (EventSource=KeyboardDidShowNotification, Action=NULL)
 didShowKeyboardNotification()
 
-// A UIButton handler (EventSource=ConfirmButton, Action=Tapped)
-confirmButtonWasTapped()
-
-// Good
-
+// good: the event source is clearly part of the function name
 // An NSNotification handler (EventSource=KeyboardDidShowNotification, Action=NULL)
 handleKeyboardDidShowNotification()
 
+// bad: unclear that this function is handling the notification
+// A UIButton handler (EventSource=ConfirmButton, Action=Tapped)
+confirmButtonWasTapped()
+
+// good: the function clearly handles the notification
 // A UIButton handler (EventSource=ConfirmButton, Action=Tapped)
 handleConfirmButtonTapped()
 ```
 ### Variables and Properties
 
-- Naming should be `camelCase`.
-- Variable names should always be descriptive with the exception of counter/index variables.
-- Include a type hint if the naming is ambiguous; e.g. `let confirm: Button` is bad, but `let confirmButton: Button` is good.
-- For booleans, prefixes such as `is` and `has` make it clear that a variable is a boolean and should be used.
+- Naming should be `lowerCamelCase`.
+- Variable names should always be descriptive with the exception of counter/index variables e.g. `index` and `counter`.
+- Include the name of the type if the naming is ambiguous; e.g. `let confirm: Button` is bad, but `let confirmButton: Button` is good.
+- For booleans, use prefixes such as `is` and `has` make it clear that a variable is a boolean.

--- a/Naming.md
+++ b/Naming.md
@@ -6,7 +6,15 @@ In general, follow the [official guidelines](https://swift.org/documentation/api
 
 ### Naming a file
 
-There's no three-letter prefix in Swift file naming. For example, if an Objective-C file named XYZEvent.m is to be converted to Swift, it should be renamed to Event.swift.
+- All Swift files should use the `.swift` extension.
+- The name of a file should make it clear what the contents are. For example, if there is a single class named `EasyTapButton` then the file should be called `EasyTapButton.swift`. If you have a view controller, along with some helper types, then using the name of the view controller will likely be the best choice. A good heuristic to use is that if it's ever unclear what to name a file, it may be worth splitting that file up.
+- There's no three-letter prefix in Swift file naming. For example, if an Objective-C file named XYZEvent.m is to be converted to Swift, it should be renamed to Event.swift.
+- If a file contains only one or more extensions, then the file name should be `MyType+Extensions.swift` unless the extension have a specific name; in that case the extension should be named `MyType+ExtensionName.swift`.
+
+### Naming a class, a struct or a protocol
+
+- Naming should be `PascalCase`
+- No Objective-C style prefixes should be used
 
 ### Naming a class or a protocol available in Objective-C
 
@@ -26,13 +34,12 @@ class Event {
 
 ### Naming a protocol
 
-There is no need to add a prefix to a Swift protocol in order to distinguish it from a Swift class or struct. 
-
-- Protocols that describe what something is should read as nouns (e.g. Collection).
-
-- Protocols that describe a capability should be named using the suffixes able, ible, or ing (e.g. Equatable, ProgressReporting)."
+- There is no need to add a prefix to a Swift protocol in order to distinguish it from a Swift class or struct. 
+- A protocol that describes what something is should read as nouns (e.g. Collection).
+- A protocol that describes a capability should be named using the suffixes able, ible, or ing (e.g. Equatable, ProgressReporting)."
 
 #### Example
+
 ``` swift
 protocol IFooEventHandler {
     // bad: the "I" prefix is not necessary
@@ -46,3 +53,54 @@ protocol FooEventHandling {
     // good
 }
 ```
+
+### Naming a delegate method
+
+The first parameter should always be the item that the delegate was called for.
+
+#### Example:
+
+```swift
+// really bad: there's no parameter for the item that the delegate was called for
+func didDeleteDraft(draft: Draft)
+
+// bad: the item that the delegate was called for is not the first parameter
+func didDeleteDraft(draft: Draft, draftManager: DraftManager)
+
+// good
+func draftManager(_ manager: DraftManager, didDeleteDraft draft: Draft)
+```
+
+### Naming an event handler method
+
+An event handler method should be name following this pattern:
+
+`handle<EventSource>[<Action>]`
+
+where `EventSource` is the UIControl or NSNotification which fired the event and `Action` is a past-tense verb described what happened.
+
+#### Example:
+
+```swift
+// Bad
+
+// An NSNotification handler (EventSource=KeyboardDidShowNotification, Action=NULL)
+didShowKeyboardNotification()
+
+// A UIButton handler (EventSource=ConfirmButton, Action=Tapped)
+confirmButtonWasTapped()
+
+// Good
+
+// An NSNotification handler (EventSource=KeyboardDidShowNotification, Action=NULL)
+handleKeyboardDidShowNotification()
+
+// A UIButton handler (EventSource=ConfirmButton, Action=Tapped)
+handleConfirmButtonTapped()
+```
+### Variables and Properties
+
+- Naming should be `camelCase`.
+- Variable names should always be descriptive with the exception of counter/index variables.
+- Include a type hint if the naming is ambiguous; e.g. `let confirm: Button` is bad, but `let confirmButton: Button` is good.
+- For booleans, prefixes such as `is` and `has` make it clear that a variable is a boolean and should be used.


### PR DESCRIPTION
Addressing #15 by merging Naming convention with Outlook swift guide's naming convention

- Added more guidelines on file naming
- Added generic guidelines on class/struct/protocol naming
- Added guidelines and examples on protocol naming
- Added guidelines and examples on delegate method and event handler method naming
- Added guidelines on variable and property naming

Note: there are a few guidelines that were not integrated in this PR but discussions are always welcome.

1. ViewController subclass naming: a subclass of `UIViewController` should use an abbreviated "VC" suffix instead of the more verbose "ViewController". This guideline was not added because the "VC" suffix does not align with Apple's naming convention; UIKit names its provided view controller classes with the full "ViewController suffix, e.g. TableViewController.
2. Class/Struct/Protocol naming components: `[Component][Type][SuperClass]`
where
- `Component` is the sub-system that the type belongs to, if any
- `Type` describes the thing itself
- `SuperClass` is the base name of the superclass, if any (similar to the least specificity from above)
This guideline was not added because class/struct/protocol naming covers many scenarios that cannot be generalized into one equation composed of three components.


