### PR TITLE
Merge Constants Convention from Outlook Swift guide

### DIFF
--- a/FileContentOrdering.md
+++ b/FileContentOrdering.md
@@ -62,3 +62,47 @@ internal func updateUnalliedHouses(_ houses: [House]) {
 private maximumHouseSize: Int = 50
 ```
 
+## Convention - Constants
+
+Use nested structs to group constants when possible.
+
+## Rationale
+
+This reduces verbosity and provides structure.
+
+## Example
+
+```swift
+class FruitSellerView: UIView {
+    ...
+
+    // bad: no separation between rotation and fade animation constants, long constant names are harder to read
+
+    static let rotationAnimationangle: CGFloat = .pi / 45.0
+    static let rotationAnimationdelay: CGFloat = 0.15
+    static let rotationAnimationduration: CGFloat = 0.3
+    static let rotationAnimationspeed: CGFloat = 100
+    static let fadeAnimationdelay: CGFloat = 0.1
+    static let fadeAnimationduration: CGFloat = 0.25
+    static let fadeAnimationspeed: CGFloat = 200
+}
+
+class FruitSellerView: UIView {
+    ...
+
+    // good: split rotation and fade animation constants into different groups
+
+    private struct RotationAnimationConstants {
+        static let angle: CGFloat = .pi / 45.0
+        static let delay: CGFloat = 0.15
+        static let duration: CGFloat = 0.3
+        static let speed: CGFloat = 100
+    }
+
+    private struct FadeAnimationConstants {
+        static let delay: CGFloat = 0.1
+        static let duration: CGFloat = 0.25
+        static let speed: CGFloat = 200
+    }
+}
+```

--- a/FileContentOrdering.md
+++ b/FileContentOrdering.md
@@ -64,7 +64,7 @@ private maximumHouseSize: Int = 50
 
 ## Convention - Constants
 
-Use nested structs to group constants when possible.
+Use structs or nested structs to group constants when possible; the grouping should be based on logical use instead of structure or type of the constants.
 
 ## Rationale
 
@@ -77,14 +77,21 @@ class FruitSellerView: UIView {
     ...
 
     // bad: no separation between rotation and fade animation constants, long constant names are harder to read
+    private struct Constants {
+        static let rotationAnimationAngle: CGFloat = .pi / 45.0
+        static let rotationAnimationDelay: CGFloat = 0.15
+        static let rotationAnimationDuration: CGFloat = 0.3
+        static let rotationAnimationSpeed: CGFloat = 100
+        static let fadeAnimationDelay: CGFloat = 0.1
+        static let fadeAnimationDuration: CGFloat = 0.25
+        static let fadeAnimationSpeed: CGFloat = 200
+    }
 
-    static let rotationAnimationangle: CGFloat = .pi / 45.0
-    static let rotationAnimationdelay: CGFloat = 0.15
-    static let rotationAnimationduration: CGFloat = 0.3
-    static let rotationAnimationspeed: CGFloat = 100
-    static let fadeAnimationdelay: CGFloat = 0.1
-    static let fadeAnimationduration: CGFloat = 0.25
-    static let fadeAnimationspeed: CGFloat = 200
+    // bad: the name "Strings" does not provide helpful about how the constants are used.
+    private struct Strings {
+        static let rotationAnimationIdentifier: String = "FruitSellerViewRotationAnimationIdentifier"
+        static let fadeAnimationIdentifier: String = "FruitSellerViewFadeAnimationIdentifier"
+    }
 }
 
 class FruitSellerView: UIView {
@@ -97,12 +104,14 @@ class FruitSellerView: UIView {
         static let delay: CGFloat = 0.15
         static let duration: CGFloat = 0.3
         static let speed: CGFloat = 100
+        static let identifier: String = "FruitSellerViewRotationAnimationIdentifier"
     }
 
     private struct FadeAnimationConstants {
         static let delay: CGFloat = 0.1
         static let duration: CGFloat = 0.25
         static let speed: CGFloat = 200
+        static let identifier: String = "FruitSellerViewFadeAnimationIdentifier"
     }
 }
 ```


### PR DESCRIPTION
Fix #20 by adding additional Constants convention based on Outlook swift guide

-Added a section on Constants organization in FileContentOrdering.md

Note: the guidance in Outlook swift guide on putting constants on top of the file / class contradicts with our existing guidelines of ordering the file by access level, thus leaving that out of this PR.