### PR TITLE
Add Range Operator Convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The Swift coding conventions guide documents many best practices for writing Swi
 * [Immutability](Immutability.md)
 * [Naming](Naming.md)
 * [Property Observers](PropertyObservers.md)
+* [Range Operators](RangeOperators.md)
 * [Type Casting](TypeCasting.md)
 * [Type Inference](TypeInference.md)
 

--- a/RangeOperators.md
+++ b/RangeOperators.md
@@ -6,7 +6,7 @@ Prefer the half-open range operator `(a..<b)` over the closed range operator `(a
 
 ## Rationale
 
-Much like using `<` instead of `<=`, using the half-open range operator allows you to exclude the final value without the need of additional arithmetic. That being said, if you intend to use the final, the closed range operator is still suitable.
+Much like using `<` instead of `<=`, using the half-open range operator allows you to exclude the final value without the need of additional arithmetic. That being said, if you intend to use the final value, the closed range operator is still suitable.
 
 ## Examples
 

--- a/RangeOperators.md
+++ b/RangeOperators.md
@@ -46,15 +46,5 @@ for i in 0..<count {
 //four
 //five
 
-// good: One-Sided Ranges can also be used to show the range is from the start to just before `count`
-for number in oneToFive[..<count] {
-    print(number)
-}
-//one
-//two
-//three
-//four
-//five
-
 ## Resources
 [Range Operators](https://docs.swift.org/swift-book/LanguageGuide/BasicOperators.html#ID73)

--- a/RangeOperators.md
+++ b/RangeOperators.md
@@ -26,7 +26,7 @@ for i in 0...count {
 //five
 //Fatal error: Index is out of range
 
-// bad:
+// bad: Additional arithemtic makes the end value less clear
 for i in 0...count-1 {
     print(oneToFive[i])
 }
@@ -36,7 +36,7 @@ for i in 0...count-1 {
 //four
 //five
 
-// good:
+// good: Clearly shows that loop will end just before `count`
 for i in 0..<count {
     print(oneToFive[i])
 }
@@ -46,7 +46,7 @@ for i in 0..<count {
 //four
 //five
 
-// good: One-Sided Ranges can also be used
+// good: One-Sided Ranges can also be used to show the range is from the start to just before `count`
 for number in oneToFive[..<count] {
     print(number)
 }
@@ -55,26 +55,6 @@ for number in oneToFive[..<count] {
 //three
 //four
 //five
-
-// fine:
-for i in 1...5 {
-    print(i)
-}
-//1
-//2
-//3
-//4
-//5
-```
-
-### Repeated Actions
-```swift
-// bad:
-let tenRandomNumbers: [Float] = (1...10).map {_ in Float.random(in: 0..<1)}
-
-// good:
-let tenRandomNumbers: [Float] = (0..<10).map {_ in Float.random(in: 0..<1)}
-```
 
 ## Resources
 [Range Operators](https://docs.swift.org/swift-book/LanguageGuide/BasicOperators.html#ID73)

--- a/RangeOperators.md
+++ b/RangeOperators.md
@@ -17,34 +17,34 @@ let count = oneToFive.count
 
 // really bad: off by one
 for i in 0...count {
-    print(oneToFive[i])
+    print("\(i+1) is \(oneToFive[i])")
 }
-//one
-//two
-//three
-//four
-//five
+//1 is one
+//2 is two
+//3 is three
+//4 is four
+//5 is five
 //Fatal error: Index is out of range
 
 // bad: Additional arithemtic makes the end value less clear
 for i in 0...count-1 {
-    print(oneToFive[i])
+    print("\(i+1) is \(oneToFive[i])")
 }
-//one
-//two
-//three
-//four
-//five
+//1 is one
+//2 is two
+//3 is three
+//4 is four
+//5 is five
 
 // good: Clearly shows that loop will end just before `count`
 for i in 0..<count {
-    print(oneToFive[i])
+    print("\(i+1) is \(oneToFive[i])")
 }
-//one
-//two
-//three
-//four
-//five
+//1 is one
+//2 is two
+//3 is three
+//4 is four
+//5 is five
 
 ## Resources
 [Range Operators](https://docs.swift.org/swift-book/LanguageGuide/BasicOperators.html#ID73)

--- a/RangeOperators.md
+++ b/RangeOperators.md
@@ -1,0 +1,80 @@
+# Range Operators
+
+## Convention
+
+Prefer the half-open range operator `(a..<b)` over the closed range operator `(a...b)` when not including the final value.
+
+## Rationale
+
+Much like using `<` instead of `<=`, using the half-open range operator allows you to exclude the final value without the need of additional arithmetic. That being said, if you intend to use the final, the closed range operator is still suitable.
+
+## Examples
+
+### Array Iteration
+```swift
+let oneToFive = ["one", "two", "three", "four", "five"]
+let count = oneToFive.count
+
+// really bad: off by one
+for i in 0...count {
+    print(oneToFive[i])
+}
+//one
+//two
+//three
+//four
+//five
+//Fatal error: Index is out of range
+
+// bad:
+for i in 0...count-1 {
+    print(oneToFive[i])
+}
+//one
+//two
+//three
+//four
+//five
+
+// good:
+for i in 0..<count {
+    print(oneToFive[i])
+}
+//one
+//two
+//three
+//four
+//five
+
+// good: One-Sided Ranges can also be used
+for number in oneToFive[..<count] {
+    print(number)
+}
+//one
+//two
+//three
+//four
+//five
+
+// fine:
+for i in 1...5 {
+    print(i)
+}
+//1
+//2
+//3
+//4
+//5
+```
+
+### Repeated Actions
+```swift
+// bad:
+let tenRandomNumbers: [Float] = (1...10).map {_ in Float.random(in: 0..<1)}
+
+// good:
+let tenRandomNumbers: [Float] = (0..<10).map {_ in Float.random(in: 0..<1)}
+```
+
+## Resources
+[Range Operators](https://docs.swift.org/swift-book/LanguageGuide/BasicOperators.html#ID73)


### PR DESCRIPTION
Add a new convention to promote using the half-open range operator over the closed range operator when excluding the final value