### PR TITLE
Add CODEOWNERS file to the repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in
+# the repo. @microsoft/apple-ux-guidance will be requested for
+# review when someone opens a pull request.
+*    @microsoft/apple-ux-guidance


### PR DESCRIPTION
Adding a CODEOWNERS file to automatically request review from Apple UX Guidance team per creation of a PR.
Followed instructions [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).